### PR TITLE
fix: sandbox highlight.js

### DIFF
--- a/src/sandbox/services/highlightjs.js
+++ b/src/sandbox/services/highlightjs.js
@@ -1,4 +1,4 @@
-import hljs from 'highlight.js/lib/highlight';
+import hljs from 'highlight.js/lib/core';
 import javascript from 'highlight.js/lib/languages/javascript';
 import json from 'highlight.js/lib/languages/json';
 


### PR DESCRIPTION
Fix for `highlight.js` to load the code block on the sandbox